### PR TITLE
pipeline: TrivialExecutor: implement all interface methods

### DIFF
--- a/pipeline/src/TrivialExecutor.java
+++ b/pipeline/src/TrivialExecutor.java
@@ -8,11 +8,11 @@ public class TrivialExecutor implements ExecutorInterface {
         return Status.OK;
     }
 
-    public Status setProducer( ProducerConsumerInterface producer ) {
+    public Status setProducer( ExecutorInterface producer ) {
         return Status.OK;
     }
 
-    public Status setConsumer( ProducerConsumerInterface consumer ) {
+    public Status setConsumer( ExecutorInterface consumer ) {
         return Status.OK;
     }
 
@@ -29,6 +29,10 @@ public class TrivialExecutor implements ExecutorInterface {
     }
 
     public Status get( byte[] ba ) {
+        return Status.OK;
+    }
+
+    public Status setConfig( String filename ) {
         return Status.OK;
     }
 }


### PR DESCRIPTION
В TrivialExecutor были реализованы не все методы интерфейса, а два реализованы ошибочно, что приводило к ошибкам компиляции. Исправил.

P. S. Зачем в `.gitignore` добавлена `.idea`? ИМХО достаточно игнорировать `.idea/workspace.iml`, а иначе нужно сделать пару движений после клонирования, прежде чем проект начинает работать. Плюс унификация SDK и библиотек также поспособствовала бы потенциальному уменьшению несовместимостей.